### PR TITLE
Removed SUPPORT_* will be deprecaded in 2025 warning

### DIFF
--- a/custom_components/pcc/cover.py
+++ b/custom_components/pcc/cover.py
@@ -7,10 +7,8 @@ from homeassistant.components.cover import (
     DEVICE_CLASSES_SCHEMA,
     ENTITY_ID_FORMAT,
     PLATFORM_SCHEMA,
-    SUPPORT_CLOSE,
-    SUPPORT_OPEN,
-    SUPPORT_STOP,
     CoverEntity,
+    CoverEntityFeature,
 )
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
@@ -89,7 +87,7 @@ async def _async_create_entities(hass, config):
     covers = []
 
     for object_id, entity_config in config[CONF_COVERS].items():
-        entity_config = rewrite_common_legacy_to_modern_conf(entity_config)
+        entity_config = rewrite_common_legacy_to_modern_conf(hass,entity_config)
 
         unique_id = entity_config.get(CONF_UNIQUE_ID)
 
@@ -259,10 +257,10 @@ class PCCCover(TemplateEntity, CoverEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        supported_features = SUPPORT_OPEN | SUPPORT_CLOSE
+        supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
 
         if self._stop_script is not None:
-            supported_features |= SUPPORT_STOP
+            supported_features |= CoverEntityFeature.STOP
 
         return supported_features
 

--- a/custom_components/pcc/cover.py
+++ b/custom_components/pcc/cover.py
@@ -198,7 +198,7 @@ class PCCCover(TemplateEntity, CoverEntity):
         self._resetOpeningTimer()
         def _timer_done():
             self._opening_timer = None
-            self.async_schedule_update_ha_state()
+            self.hass.loop.call_soon_threadsafe(self.async_schedule_update_ha_state)
         
         self._opening_timer = Timer(self._travel_time_up, _timer_done)
         self._opening_timer.start()
@@ -212,7 +212,7 @@ class PCCCover(TemplateEntity, CoverEntity):
         self._resetClosingTimer()
         def _timer_done():
             self._closing_timer = None
-            self.async_schedule_update_ha_state()
+            self.hass.loop.call_soon_threadsafe(self.async_schedule_update_ha_state)
         
         self._closing_timer = Timer(self._travel_time_down, _timer_done)
         self._closing_timer.start()


### PR DESCRIPTION
Hi! 
Removed SUPPORT_* will be deprecated warning and update the  rewrite_common_legacy_to_modern_conf as it now requires an additional  variable.

There is still an issue with ( see below) when restarting. But everything seems to work as expected now.

```
Update for cover.pcc_garage_door fails

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 944, in async_update_ha_state
    await self.async_device_update()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1302, in async_device_update
    await self.async_update()
  File "/usr/src/homeassistant/homeassistant/components/template/template_entity.py", line 582, in async_update
    assert self._template_result_info
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```